### PR TITLE
ADD clear screen syscall

### DIFF
--- a/mars/mips/instructions/syscalls/SyscallClearScreen.java
+++ b/mars/mips/instructions/syscalls/SyscallClearScreen.java
@@ -1,0 +1,35 @@
+package mars.mips.instructions.syscalls;
+
+import mars.*;
+import mars.mips.instructions.syscalls.AbstractSyscall;
+import mars.ProcessingException;
+import mars.ProgramStatement;
+import javax.swing.*;
+
+/**
+ * Syscall 60: Clear the Run I/O console window in MARS (GUI only).
+ *
+ * Usage in MIPS:
+ *   li $v0, 60
+ *   syscall
+ */
+public class SyscallClearScreen extends AbstractSyscall {
+
+    public SyscallClearScreen() {
+        super(60, "ClearScreen");
+    }
+
+    @Override
+    public void simulate(ProgramStatement statement) throws ProcessingException {
+        // Only works when GUI is active
+        if (Globals.getGui() == null) return;
+
+        JTextArea runConsole = Globals.getGui()
+                .getMessagesPane()
+                .getRunTextArea();
+
+        if (runConsole != null) {
+            SwingUtilities.invokeLater(() -> runConsole.setText(""));
+        }
+    }
+}


### PR DESCRIPTION
We introduced this syscall to clear the Run I/O screen during a project at University College London, allowing for a more dynamic use of the text area. Hopefully it can be useful to others too.