### PR TITLE
Fixes unescaped > in doc-comments

### DIFF
--- a/mars/mips/instructions/InstructionSet.java
+++ b/mars/mips/instructions/InstructionSet.java
@@ -1672,7 +1672,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         round = Integer.MAX_VALUE;
                      } 
                      else {
-                        Float floatObj = new Float(floatValue);
+                        Float floatObj = Float.valueOf(floatValue);
                         // If we are EXACTLY in the middle, then round to even!  To determine this,
                         // find next higher integer and next lower integer, then see if distances 
                         // are exactly equal.
@@ -1920,7 +1920,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         round = Integer.MAX_VALUE;
                      } 
                      else {
-                        Double doubleObj = new Double(doubleValue);
+                        Double doubleObj = Double.valueOf(doubleValue);
                         // If we are EXACTLY in the middle, then round to even!  To determine this,
                         // find next higher integer and next lower integer, then see if distances 
                         // are exactly equal.

--- a/mars/tools/AbstractMarsToolAndApplication.java
+++ b/mars/tools/AbstractMarsToolAndApplication.java
@@ -514,7 +514,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
    	 *  since it will remove the app as a memory observer regardless of the subrange
    	 *  or number of subranges it is registered for.
    	 *  @param lowEnd low end of memory address range.
-   	 *  @param highEnd high end of memory address range; must be >= lowEnd
+   	 *  @param highEnd high end of memory address range; must be &gt;= lowEnd
    	 */
    	
        protected void addAsObserver(int lowEnd, int highEnd) {

--- a/mars/util/Binary.java
+++ b/mars/util/Binary.java
@@ -237,7 +237,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
      * 
      * @param value The String value to convert.
      * @return char '0', '1', ...'F' which form hexadecimal equivalent of decoded String.
-     * If string length > 4, returns '0'.
+     * If string length &gt; 4, returns '0'.
      **/   
    
        public static char binaryStringToHexDigit(String value) {

--- a/mars/util/SystemIO.java
+++ b/mars/util/SystemIO.java
@@ -132,7 +132,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                input = Globals.getGui().getMessagesPane().getInputString(-1);
             }
          }
-         return new Float(input.trim()).floatValue();
+         return Float.parseFloat(input.trim());
       
       }
     
@@ -166,7 +166,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                input = Globals.getGui().getMessagesPane().getInputString(-1);
             }
          }
-         return new Double(input.trim()).doubleValue();
+         return Double.parseDouble(input.trim());
       
       }
     

--- a/mars/venus/EditCopyAction.java
+++ b/mars/venus/EditCopyAction.java
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the Edit -> Copy menu item
+    * Action  for the Edit -&gt; Copy menu item
     */   			
     public class EditCopyAction extends GuiAction {
    	 

--- a/mars/venus/EditCutAction.java
+++ b/mars/venus/EditCutAction.java
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the Edit -> Cut menu item
+    * Action  for the Edit -&gt; Cut menu item
     */   			
     public class EditCutAction extends GuiAction {
    	 

--- a/mars/venus/EditFindReplaceAction.java
+++ b/mars/venus/EditFindReplaceAction.java
@@ -34,7 +34,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the Edit -> Find/Replace menu item
+    * Action  for the Edit -&gt; Find/Replace menu item
     */   			
     public class EditFindReplaceAction extends GuiAction {
       private static String searchString = "";

--- a/mars/venus/EditPasteAction.java
+++ b/mars/venus/EditPasteAction.java
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the Edit -> Paste menu item
+    * Action  for the Edit -&gt; Paste menu item
     */   			
     public class EditPasteAction extends GuiAction {
    	 

--- a/mars/venus/EditRedoAction.java
+++ b/mars/venus/EditRedoAction.java
@@ -34,7 +34,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the Edit -> Redo menu item
+    * Action  for the Edit -&gt; Redo menu item
     */   			
     public class EditRedoAction extends GuiAction {
    	 

--- a/mars/venus/EditSelectAllAction.java
+++ b/mars/venus/EditSelectAllAction.java
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the Edit -> Copy menu item
+    * Action  for the Edit -&gt; Copy menu item
     */   			
     public class EditSelectAllAction extends GuiAction {
    	 

--- a/mars/venus/EditUndoAction.java
+++ b/mars/venus/EditUndoAction.java
@@ -34,7 +34,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the Edit -> Undo menu item
+    * Action  for the Edit -&gt; Undo menu item
     */   			
     public class EditUndoAction extends GuiAction {
    	 

--- a/mars/venus/Editor.java
+++ b/mars/venus/Editor.java
@@ -244,8 +244,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     * loss of editing changes.  Specifically: if there is a current
     * file open for editing and its modify flag is true, then give user
     * a dialog box with choice to save, discard edits, or cancel and
-    * carry out the decision.  This applies to File->New, File->Open,
-    * File->Close, and File->Exit.
+    * carry out the decision.  This applies to File -&gt; New, File -&gt; Open,
+    * File -&gt; Close, and File -&gt; Exit.
     *
     * @return false means user selected Cancel so caller should do that.
     * Return of true means caller can proceed (edits were saved or discarded).

--- a/mars/venus/ExecutePane.java
+++ b/mars/venus/ExecutePane.java
@@ -162,7 +162,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
    	 
       /** Clears out all components of the Execute tab: text segment
    	 * display, data segment display, label display and register display.
-   	 * This will typically be done upon File->Close, Open, New.
+   	 * This will typically be done upon File -&gt; Close, Open, New.
    	 */
    	
        public void clearPane() {

--- a/mars/venus/FileCloseAction.java
+++ b/mars/venus/FileCloseAction.java
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
  
     /**
-    * Action  for the File -> Close menu item
+    * Action  for the File -&gt; Close menu item
     */   			
     public class FileCloseAction extends GuiAction {
    	 

--- a/mars/venus/FileCloseAllAction.java
+++ b/mars/venus/FileCloseAllAction.java
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
  
     /**
-    * Action  for the File -> Close All menu item
+    * Action  for the File -&gt; Close All menu item
     */   			
     public class FileCloseAllAction extends GuiAction {
    	 

--- a/mars/venus/FileDumpMemoryAction.java
+++ b/mars/venus/FileDumpMemoryAction.java
@@ -40,7 +40,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the File -> Save For Dump Memory menu item
+    * Action  for the File -&gt; Save For Dump Memory menu item
     */   			
     public class FileDumpMemoryAction extends GuiAction {
     

--- a/mars/venus/FileExitAction.java
+++ b/mars/venus/FileExitAction.java
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the File -> Exit menu item
+    * Action  for the File -&gt; Exit menu item
     */   			
     public class FileExitAction extends GuiAction {
    	 

--- a/mars/venus/FileNewAction.java
+++ b/mars/venus/FileNewAction.java
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the File -> New menu item
+    * Action  for the File -&gt; New menu item
     */   			
     public class FileNewAction extends GuiAction {
    	 

--- a/mars/venus/FileOpenAction.java
+++ b/mars/venus/FileOpenAction.java
@@ -38,7 +38,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
  
     /**
-    * Action  for the File -> Open menu item
+    * Action  for the File -&gt; Open menu item
     */   			
     public class FileOpenAction extends GuiAction {
     

--- a/mars/venus/FilePrintAction.java
+++ b/mars/venus/FilePrintAction.java
@@ -36,7 +36,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
  
     /**
-    * Action  for the File -> Print menu item
+    * Action  for the File -&gt; Print menu item
     */   			
     public class FilePrintAction extends GuiAction {
    	 

--- a/mars/venus/FileSaveAction.java
+++ b/mars/venus/FileSaveAction.java
@@ -34,7 +34,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
  
     /**
-    * Action  for the File -> Save menu item
+    * Action  for the File -&gt; Save menu item
     */   			
     public class FileSaveAction extends GuiAction {
    	 

--- a/mars/venus/FileSaveAllAction.java
+++ b/mars/venus/FileSaveAllAction.java
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
  
     /**
-    * Action  for the File -> Close All menu item
+    * Action  for the File -&gt; Close All menu item
     */   			
     public class FileSaveAllAction extends GuiAction {
    	 

--- a/mars/venus/FileSaveAsAction.java
+++ b/mars/venus/FileSaveAsAction.java
@@ -34,7 +34,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the File -> Save As menu item
+    * Action  for the File -&gt; Save As menu item
     */   			
     public class FileSaveAsAction extends GuiAction {
    	 

--- a/mars/venus/HelpAboutAction.java
+++ b/mars/venus/HelpAboutAction.java
@@ -33,7 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the Help -> About menu item
+    * Action  for the Help -&gt; About menu item
     */   			
     public class HelpAboutAction extends GuiAction {
        public  HelpAboutAction(String name, Icon icon, String descrip,

--- a/mars/venus/HelpHelpAction.java
+++ b/mars/venus/HelpHelpAction.java
@@ -39,7 +39,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the Help -> Help menu item
+    * Action  for the Help -&gt; Help menu item
     */   			
     public class HelpHelpAction extends GuiAction {
        public  HelpHelpAction(String name, Icon icon, String descrip,

--- a/mars/venus/RunAssembleAction.java
+++ b/mars/venus/RunAssembleAction.java
@@ -37,7 +37,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
  
    /**
-    * Action class for the Run -> Assemble menu item (and toolbar icon)
+    * Action class for the Run -&gt; Assemble menu item (and toolbar icon)
     */
     public class RunAssembleAction extends GuiAction {
    	 

--- a/mars/venus/RunBackstepAction.java
+++ b/mars/venus/RunBackstepAction.java
@@ -34,7 +34,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the Run -> Backstep menu item
+    * Action  for the Run -&gt; Backstep menu item
     */   			
     public class RunBackstepAction extends GuiAction {
    	 

--- a/mars/venus/RunGoAction.java
+++ b/mars/venus/RunGoAction.java
@@ -38,7 +38,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
    /**
-    * Action class for the Run -> Go menu item (and toolbar icon)
+    * Action class for the Run -&gt; Go menu item (and toolbar icon)
     */
     public class RunGoAction extends GuiAction  {
    	

--- a/mars/venus/RunPauseAction.java
+++ b/mars/venus/RunPauseAction.java
@@ -35,7 +35,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
    /**
-    * Action class for the Run -> Pause menu item (and toolbar icon)
+    * Action class for the Run -&gt; Pause menu item (and toolbar icon)
     */
     public class RunPauseAction extends GuiAction  {
    	

--- a/mars/venus/RunResetAction.java
+++ b/mars/venus/RunResetAction.java
@@ -35,7 +35,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
    /**
-    * Action  for the Run -> Reset menu item
+    * Action  for the Run -&gt; Reset menu item
     */   
     public class RunResetAction extends GuiAction {
    	 

--- a/mars/venus/RunStepAction.java
+++ b/mars/venus/RunStepAction.java
@@ -35,7 +35,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
     /**
-    * Action  for the Run -> Step menu item
+    * Action  for the Run -&gt; Step menu item
     */   			
     public class RunStepAction extends GuiAction {
    	 

--- a/mars/venus/RunStopAction.java
+++ b/mars/venus/RunStopAction.java
@@ -35,7 +35,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 	
    /**
-    * Action class for the Run -> Stop menu item (and toolbar icon)
+    * Action class for the Run -&gt; Stop menu item (and toolbar icon)
     */
     public class RunStopAction extends GuiAction  {
    	

--- a/mars/venus/VenusUI.java
+++ b/mars/venus/VenusUI.java
@@ -892,7 +892,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
          editRedoAction.updateRedoState();
       }
    
-     /* Use this when "File -> New" is used
+     /* Use this when "File -&gt; New" is used
       */
        void setMenuStateEditingNew() {
       /* Note: undo and redo are handled separately by the undo manager*/  
@@ -1133,9 +1133,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       }   	          
    	
    	/**
-   	 * Return reference tothe Run->Assemble item's action.  Needed by File->Open in case
+   	 * Return reference to the Run -&gt; Assemble item's action.  Needed by File -&gt; Open in case
    	 * assemble-upon-open flag is set.
-   	 * @return the Action object for the Run->Assemble operation.
+   	 * @return the Action object for the Run -&gt; Assemble operation.
    	 */
        public Action getRunAssembleAction() {
          return runAssembleAction;


### PR DESCRIPTION
More recent java versions complain about the unescaped ">" char in the doc comments and return an error state which prevents git-actions from working.

The PR fixes the ">" error and additional calls to "new Float" and "new Double"